### PR TITLE
Allow multiple uses of Attestations

### DIFF
--- a/contracts/KetlAttestation.sol
+++ b/contracts/KetlAttestation.sol
@@ -81,7 +81,7 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
   mapping(uint => IncrementalTreeData) public entanglementsTrees;
   mapping(uint => uint[]) public entanglements;
   mapping(uint => mapping(uint => bool)) public entanglementsRoots;
-  mapping(uint => Counters.Counter) public attestationHashesEntangled;
+  mapping(uint => Counters.Counter) public attestationHashesEntangledCount;
   uint public maximumEntanglementsPerAttestation = 1;
 
   mapping(uint => Counters.Counter) public entanglementsCounts;
@@ -144,6 +144,14 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
     currentTokenId = _currentTokenId;
   }
 
+  function attestationHashesEntangled(
+    uint _attestationHash
+  ) public view returns (bool) {
+    return
+      attestationHashesEntangledCount[_attestationHash].current() >=
+      maximumEntanglementsPerAttestation;
+  }
+
   function registerEntanglement(
     uint[2] memory a,
     uint[2][2] memory b,
@@ -163,7 +171,7 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
     );
     // Check if this attestation has already been used
     require(
-      attestationHashesEntangled[attestationHash].current() <= maximumEntanglementsPerAttestation,
+      !attestationHashesEntangled(attestationHash),
       "Attestation has been used too many times"
     );
     // Check the attestations merkle root
@@ -177,7 +185,7 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
       "Attestation public key is wrong"
     );
     // Save the entanglement fact
-    attestationHashesEntangled[attestationHash].increment();
+    attestationHashesEntangledCount[attestationHash].increment();
     // Add the entanglement to the tree
     entanglementsTrees[attestationType].insert(entanglement);
     // Save the entanglement in the array

--- a/contracts/KetlAttestation.sol
+++ b/contracts/KetlAttestation.sol
@@ -81,7 +81,8 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
   mapping(uint => IncrementalTreeData) public entanglementsTrees;
   mapping(uint => uint[]) public entanglements;
   mapping(uint => mapping(uint => bool)) public entanglementsRoots;
-  mapping(uint => bool) public attestationHashesEntangled;
+  mapping(uint => Counters.Counter) public attestationHashesEntangled;
+  uint public maximumEntanglementsPerAttestation = 1;
 
   mapping(uint => Counters.Counter) public entanglementsCounts;
   mapping(uint => uint16) public minimumEntanglementCounts;
@@ -133,6 +134,12 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
     minimumEntanglementCounts[_id] = _minimumEntanglementCount;
   }
 
+  function setMaximumEntanglementsPerAttestation(
+    uint _maximumEntanglementsPerAttestation
+  ) public onlyOwner {
+    maximumEntanglementsPerAttestation = _maximumEntanglementsPerAttestation;
+  }
+
   function setCurrentTokenId(uint32 _currentTokenId) public onlyOwner {
     currentTokenId = _currentTokenId;
   }
@@ -156,8 +163,8 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
     );
     // Check if this attestation has already been used
     require(
-      !attestationHashesEntangled[attestationHash],
-      "Attestation has already been entangled"
+      !attestationHashesEntangled[attestationHash].current() <= maximumEntanglementsPerAttestation,
+      "Attestation has been used too many times"
     );
     // Check the attestations merkle root
     require(
@@ -170,7 +177,7 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
       "Attestation public key is wrong"
     );
     // Save the entanglement fact
-    attestationHashesEntangled[attestationHash] = true;
+    attestationHashesEntangled[attestationHash].increment();
     // Add the entanglement to the tree
     entanglementsTrees[attestationType].insert(entanglement);
     // Save the entanglement in the array

--- a/contracts/KetlAttestation.sol
+++ b/contracts/KetlAttestation.sol
@@ -163,7 +163,7 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
     );
     // Check if this attestation has already been used
     require(
-      !attestationHashesEntangled[attestationHash].current() <= maximumEntanglementsPerAttestation,
+      attestationHashesEntangled[attestationHash].current() <= maximumEntanglementsPerAttestation,
       "Attestation has been used too many times"
     );
     // Check the attestations merkle root

--- a/contracts/KetlAttestation.sol
+++ b/contracts/KetlAttestation.sol
@@ -84,7 +84,6 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
   // Attestations to total number of entanglements
   mapping(uint => Counters.Counter) public attestationHashesEntangled;
   mapping(uint => uint16) public maxEntanglementsPerAttestation;
-  uint16 public globalMaxEntanglementsPerAttestation = 1;
 
   mapping(uint => Counters.Counter) public entanglementsCounts;
   mapping(uint => uint16) public minimumEntanglementCounts;
@@ -136,12 +135,6 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
     minimumEntanglementCounts[_id] = _minimumEntanglementCount;
   }
 
-  function setGlobalMaxEntanglementsPerAttestation(
-    uint16 _globalMaxEntanglementsPerAttestation
-  ) public onlyOwner {
-    globalMaxEntanglementsPerAttestation = _globalMaxEntanglementsPerAttestation;
-  }
-
   function setMaxEntanglementsPerAttestation(
     uint _attestationHash,
     uint16 _maxEntanglementsPerAttestation
@@ -173,13 +166,10 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
       "Invalid ZK proof"
     );
     // Check if this attestation has already been used
-    uint maximumEntangements = maxEntanglementsPerAttestation[attestationHash] >
-      0
-      ? maxEntanglementsPerAttestation[attestationHash]
-      : globalMaxEntanglementsPerAttestation;
     require(
-      attestationHashesEntangled[attestationHash].current() <
-        maximumEntangements,
+      attestationHashesEntangled[attestationHash].current() == 0 ||
+        attestationHashesEntangled[attestationHash].current() <
+        maxEntanglementsPerAttestation[attestationHash],
       "Attestation has been used too many times"
     );
     // Check the attestations merkle root

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,25 @@
+import {
+  IncrementalBinaryTree,
+  IncrementalBinaryTree__factory,
+  KetlAttestation,
+  KetlAttestation__factory,
+  PoseidonT3,
+  PoseidonT3__factory,
+} from '../typechain'
+import { MockContract } from 'ethereum-waffle'
+
+declare module 'mocha' {
+  export interface Context {
+    // Factories for contracts
+    poseidonT3Factory: PoseidonT3__factory
+    incrementalBinaryTreeFactory: IncrementalBinaryTree__factory
+    ketlAttestationFactory: KetlAttestation__factory
+    // Contract instances
+    poseidonT3: PoseidonT3
+    incrementalBinaryTree: IncrementalBinaryTree
+    ketlAttestation: KetlAttestation
+    // Mock contracts
+    fakeAttestationCheckerVerifier: MockContract
+    fakePasswordCheckerVerifier: MockContract
+  }
+}

--- a/test/utils/fakes.ts
+++ b/test/utils/fakes.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers'
 import { KetlAttestation } from 'typechain'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { deployMockContract } from 'ethereum-waffle'

--- a/test/utils/fakes.ts
+++ b/test/utils/fakes.ts
@@ -1,0 +1,67 @@
+import { BigNumber } from 'ethers'
+import { KetlAttestation } from 'typechain'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { deployMockContract } from 'ethereum-waffle'
+
+export function getFakeAttestationCheckerVerifier(signer: SignerWithAddress) {
+  return deployMockContract(signer, [
+    {
+      inputs: [
+        { internalType: 'uint256[2]', name: 'a', type: 'uint256[2]' },
+        { internalType: 'uint256[2][2]', name: 'b', type: 'uint256[2][2]' },
+        { internalType: 'uint256[2]', name: 'c', type: 'uint256[2]' },
+        { internalType: 'uint256[5]', name: 'input', type: 'uint256[5]' },
+      ],
+      name: 'verifyProof',
+      outputs: [{ internalType: 'bool', name: 'r', type: 'bool' }],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ])
+}
+
+export function getFakePasswordCheckerVerifier(signer: SignerWithAddress) {
+  return deployMockContract(signer, [
+    {
+      inputs: [
+        { internalType: 'uint256[2]', name: 'a', type: 'uint256[2]' },
+        { internalType: 'uint256[2][2]', name: 'b', type: 'uint256[2][2]' },
+        { internalType: 'uint256[2]', name: 'c', type: 'uint256[2]' },
+        { internalType: 'uint256[3]', name: 'input', type: 'uint256[3]' },
+      ],
+      name: 'verifyProof',
+      outputs: [{ internalType: 'bool', name: 'r', type: 'bool' }],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ])
+}
+
+export function getMockProof(
+  attestationType: number,
+  attestationMerkleRoot: number,
+  entanglement: number,
+  attestationHash: number,
+  attestorPublicKey: number
+): {
+  a: Parameters<KetlAttestation['registerEntanglement']>[0]
+  b: Parameters<KetlAttestation['registerEntanglement']>[1]
+  c: Parameters<KetlAttestation['registerEntanglement']>[2]
+  input: Parameters<KetlAttestation['registerEntanglement']>[3]
+} {
+  return {
+    a: [1, 2],
+    b: [
+      [1, 2],
+      [3, 4],
+    ],
+    c: [1, 2],
+    input: [
+      attestationType,
+      attestationMerkleRoot,
+      entanglement,
+      attestationHash,
+      attestorPublicKey,
+    ],
+  }
+}


### PR DESCRIPTION
Converting `attestationHashesEntangled` directly from a map from a `uint->bool` to `uint->Counters.Counter` would break the following interfaces used in other repositories:
- In [`ketl-app`](https://github.com/BigWhaleLabs/ketl-app/blob/9f9596989189927e94f73e8a6775ecb496e92654/src/helpers/blockchain/entanglements/isRegisteredBefore.ts#L5C1-L9)
- In [`ketl-zk-frontend`](https://github.com/BigWhaleLabs/ketl-zk-frontend/blob/0474c52da2b38c41a77d62cd85220d2b77247419/src/helpers/checkAttestationHash.ts#L3-L8)

Therefore, I introduced maintained this interface and renamed `attestationHashesEntangled` to `attestationHashesEntangledCount`. 