### PR TITLE
Add function to set nullifiers

### DIFF
--- a/contracts/KetlAttestation.sol
+++ b/contracts/KetlAttestation.sol
@@ -90,6 +90,7 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
   mapping(uint => bool) public nullifiers;
   // Legacy
   bool public legacyMintLocked;
+  bool public legacySetNullifiersLocked;
 
   // Events
   event EntanglementRegistered(uint attestationType, uint entanglement);
@@ -231,6 +232,17 @@ contract KetlAttestation is ERC1155, Ownable, Versioned, ERC2771Recipient {
 
   function lockLegacyMint() external onlyOwner {
     legacyMintLocked = true;
+  }
+
+  function legacySetNullifers(uint[] calldata _nullifiers) external onlyOwner {
+    require(!legacySetNullifiersLocked, "Legacy set nullifiers is locked");
+    for (uint i = 0; i < _nullifiers.length; i++) {
+      nullifiers[_nullifiers[i]] = true;
+    }
+  }
+
+  function lockLegacySetNullifiers() external onlyOwner {
+    legacySetNullifiersLocked = true;
   }
 
   // Make it soulbound


### PR DESCRIPTION
SSIA: Add a function to set nullifiers in a batch

Note: We don't actually need a `legacyRegisterEntanglement` function because anyone can call the function to register an entanglement. It's not linked to `msg.sender` at all. 